### PR TITLE
Correct use of Task returned by TaskWorker::Start()

### DIFF
--- a/src/libs/H.WebSockets/Utilities/TaskWorker.cs
+++ b/src/libs/H.WebSockets/Utilities/TaskWorker.cs
@@ -85,7 +85,7 @@ internal partial class TaskWorker : IDisposable
             }
 
             OnCompleted();
-        }, CancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }, CancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
     }
 
     /// <summary>


### PR DESCRIPTION
Fix to the Task stored in TaskWorker, which should correspond to the awaited func in order to trigger IsCompleted correctly in WebSocketClient::ConnectAsync(). Without .Unwrap() the Task is of type Task<Task> where the inner Task corresponds to the awaited function. With .Unwrap() the Task returned is the inner Task which will have IsCompleted==true when the func has exited.

Also added a semaphore in ConnectAsync() to avoid potential multi-thread issues that can lead to ObjectDisposedException (and possibly other issues), if a second thread calls Socket.Dispose() before a first thread calls Socket.ConnectAsync().